### PR TITLE
Section entry parsing to Error instead of Panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0.75"
 regex = "1.10.2"
 log = "0.4.20"
 indexmap = "^2.1.0"
+thiserror = "1.0.50"
 
 [dev-dependencies]
 env_logger = "0.10.1"

--- a/src/err.rs
+++ b/src/err.rs
@@ -3,5 +3,5 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum ParseError<'a> {
     #[error("Invalid Format. Expected [{0}]")]
-    InvalidFormat(&'a str)
+    InvalidFormat(&'a str),
 }

--- a/src/err.rs
+++ b/src/err.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ParseError<'a> {
+    #[error("Invalid Format. Expected [{0}]")]
+    InvalidFormat(&'a str)
+}

--- a/src/inf.rs
+++ b/src/inf.rs
@@ -7,4 +7,7 @@ impl Config for Inf {
     fn has_conditionals(&self) -> bool {
         false
     }
+    fn no_fail_mode(&self) -> bool {
+        false
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,9 @@ use log::{self, debug, trace, warn};
 use regex::Regex;
 use section::Edk2SectionEntry;
 
+mod err;
 pub mod inf;
 pub mod section;
-mod err;
 
 #[cfg(windows)]
 const LINE_ENDING: &str = "\r\n";
@@ -70,12 +70,12 @@ impl<T: Config> ConfigParser<T> {
                         );
                         trace!("Entry value: [{}]", entry);
                         entries.insert(0, entry)
-                    },
-                    Err(err) => { 
+                    }
+                    Err(err) => {
                         if self.config.no_fail_mode() {
                             warn!("Failed to parse entry: {}", err);
                         } else {
-                            return Err(err.into());
+                            return Err(err);
                         }
                     }
                 }
@@ -436,7 +436,9 @@ mod config_parser_tests {
         assert_eq!(results.get(0).unwrap().path, "MyFile.c");
         assert_eq!(results.get(1).unwrap().path, "MyFile2.c");
 
-        let results = parser.get_section_entries::<SourceEntry>(Some("IA32")).unwrap();
+        let results = parser
+            .get_section_entries::<SourceEntry>(Some("IA32"))
+            .unwrap();
         assert_eq!(results.len(), 4);
         assert_eq!(results.get(2).unwrap().path, "MyFile3.c");
         assert_eq!(results.get(3).unwrap().path, "MyFile4.c");

--- a/tests/test_inf.rs
+++ b/tests/test_inf.rs
@@ -22,17 +22,18 @@ mod tests {
         let mut infp = ConfigParser::<Inf>::new();
         infp.parse(data).unwrap();
 
-        assert_eq!(infp.get_section_entries::<SourceEntry>(None).len(), 37);
+        assert_eq!(infp.get_section_entries::<SourceEntry>(None).unwrap().len(), 37);
         assert_eq!(
-            infp.get_section_entries::<SourceEntry>(Some("IA32")).len(),
+            infp.get_section_entries::<SourceEntry>(Some("IA32")).unwrap().len(),
             180
         );
         assert_eq!(
-            infp.get_section_entries::<SourceEntry>(Some("x64")).len(),
+            infp.get_section_entries::<SourceEntry>(Some("x64")).unwrap().len(),
             150
         );
         assert_eq!(
             infp.get_section_entries::<SourceEntry>(Some("IA32"))
+                .unwrap()
                 .iter()
                 .filter(|s| s.family == Some("MSFT".to_string()))
                 .count(),
@@ -40,6 +41,7 @@ mod tests {
         );
         assert_eq!(
             infp.get_section_entries::<SourceEntry>(Some("IA32"))
+                .unwrap()
                 .iter()
                 .filter(|s| s.family == Some("GCC".to_string()))
                 .count(),
@@ -48,12 +50,13 @@ mod tests {
 
         assert_eq!(
             infp.get_section_entries::<LibraryClassEntry>(Some("ia32"))
+                .unwrap()
                 .len(),
             4
         );
 
-        assert_eq!(infp.get_section_entries::<PcdEntry>(None).len(), 5);
-        assert_eq!(infp.get_section_entries::<FeaturePcdEntry>(None).len(), 1);
+        assert_eq!(infp.get_section_entries::<PcdEntry>(None).unwrap().len(), 5);
+        assert_eq!(infp.get_section_entries::<FeaturePcdEntry>(None).unwrap().len(), 1);
     }
 
     #[test]
@@ -66,32 +69,38 @@ mod tests {
 
         assert!(!infp
             .get_section_entries::<SourceEntry>(None)
+            .unwrap()
             .iter()
             .any(|s| s.path.contains("$(OPENSSL_PATH)")),);
         assert!(infp
             .get_section_entries::<SourceEntry>(None)
+            .unwrap()
             .iter()
             .any(|s| s.path == "openssl/crypto/asn1/x_sig.c"),);
 
-        assert_eq!(infp.get_section_entries::<LibraryClassEntry>(None).len(), 4);
+        assert_eq!(infp.get_section_entries::<LibraryClassEntry>(None).unwrap().len(), 4);
         assert_eq!(
             infp.get_section_entries::<LibraryClassEntry>(Some("ARM"))
+                .unwrap()
                 .len(),
             5
         );
         assert!(infp
             .get_section_entries::<LibraryClassEntry>(Some("ARM"))
+            .unwrap()
             .iter()
             .any(|s| s.name == "ArmSoftFloatLib"),);
 
         assert_eq!(
             infp.get_section_entries::<PackageEntry>(Some("common"))
+                .unwrap()
                 .len(),
             2
         );
 
         assert_eq!(
             infp.get_section_entries::<BuildOptionEntry>(None)
+                .unwrap()
                 .iter()
                 .filter(|s| s.family == Some("MSFT".to_string()))
                 .count(),
@@ -99,6 +108,7 @@ mod tests {
         );
         assert_eq!(
             infp.get_section_entries::<BuildOptionEntry>(None)
+                .unwrap()
                 .iter()
                 .filter(|s| s.family == Some("INTEL".to_string()))
                 .count(),
@@ -106,6 +116,7 @@ mod tests {
         );
         assert_eq!(
             infp.get_section_entries::<BuildOptionEntry>(None)
+                .unwrap()
                 .iter()
                 .filter(|s| s.family == Some("GCC".to_string()))
                 .count(),
@@ -113,6 +124,7 @@ mod tests {
         );
         assert_eq!(
             infp.get_section_entries::<BuildOptionEntry>(None)
+                .unwrap()
                 .iter()
                 .filter(|s| s.arch == *"IA32")
                 .count(),
@@ -120,6 +132,7 @@ mod tests {
         );
         assert_eq!(
             infp.get_section_entries::<BuildOptionEntry>(None)
+                .unwrap()
                 .iter()
                 .filter(|s| s.value.contains("$(OPENSSL_FLAGS)"))
                 .count(),
@@ -127,6 +140,7 @@ mod tests {
         );
         assert_eq!(
             infp.get_section_entries::<BuildOptionEntry>(None)
+                .unwrap()
                 .iter()
                 .filter(|s| s.value.contains("$(OPENSSL_FLAGS_CONFIG)"))
                 .count(),
@@ -142,6 +156,6 @@ mod tests {
         let mut infp = ConfigParser::<Inf>::new();
         infp.parse(data).unwrap();
 
-        assert_eq!(infp.get_section_entries::<SourceEntry>(None).len(), 1);
+        assert_eq!(infp.get_section_entries::<SourceEntry>(None).unwrap().len(), 1);
     }
 }

--- a/tests/test_inf.rs
+++ b/tests/test_inf.rs
@@ -22,13 +22,20 @@ mod tests {
         let mut infp = ConfigParser::<Inf>::new();
         infp.parse(data).unwrap();
 
-        assert_eq!(infp.get_section_entries::<SourceEntry>(None).unwrap().len(), 37);
         assert_eq!(
-            infp.get_section_entries::<SourceEntry>(Some("IA32")).unwrap().len(),
+            infp.get_section_entries::<SourceEntry>(None).unwrap().len(),
+            37
+        );
+        assert_eq!(
+            infp.get_section_entries::<SourceEntry>(Some("IA32"))
+                .unwrap()
+                .len(),
             180
         );
         assert_eq!(
-            infp.get_section_entries::<SourceEntry>(Some("x64")).unwrap().len(),
+            infp.get_section_entries::<SourceEntry>(Some("x64"))
+                .unwrap()
+                .len(),
             150
         );
         assert_eq!(
@@ -56,7 +63,12 @@ mod tests {
         );
 
         assert_eq!(infp.get_section_entries::<PcdEntry>(None).unwrap().len(), 5);
-        assert_eq!(infp.get_section_entries::<FeaturePcdEntry>(None).unwrap().len(), 1);
+        assert_eq!(
+            infp.get_section_entries::<FeaturePcdEntry>(None)
+                .unwrap()
+                .len(),
+            1
+        );
     }
 
     #[test]
@@ -78,7 +90,12 @@ mod tests {
             .iter()
             .any(|s| s.path == "openssl/crypto/asn1/x_sig.c"),);
 
-        assert_eq!(infp.get_section_entries::<LibraryClassEntry>(None).unwrap().len(), 4);
+        assert_eq!(
+            infp.get_section_entries::<LibraryClassEntry>(None)
+                .unwrap()
+                .len(),
+            4
+        );
         assert_eq!(
             infp.get_section_entries::<LibraryClassEntry>(Some("ARM"))
                 .unwrap()
@@ -156,6 +173,9 @@ mod tests {
         let mut infp = ConfigParser::<Inf>::new();
         infp.parse(data).unwrap();
 
-        assert_eq!(infp.get_section_entries::<SourceEntry>(None).unwrap().len(), 1);
+        assert_eq!(
+            infp.get_section_entries::<SourceEntry>(None).unwrap().len(),
+            1
+        );
     }
 }


### PR DESCRIPTION
Parsing a section entry is done through `from_key_value_pair` (previously `new`) and would panic if the format of a line was not as expected. This function has been updated to return a Result object so that a failure in parsing a section entry line can be handled depending on the user. This change allows for an additional config, `no_fail_mode`, which will simply log a warning when an entry could not be parsed, rather than panicking.