### PR TITLE
Do not lazy parse

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -13,7 +13,8 @@
     "ignoreWords": [
         "myfile",
         "dlink",
-        "infp"
+        "infp",
+        "rmps"
     ],
     "words": [
         "ppis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ regex = "1.10.2"
 log = "0.4.20"
 indexmap = "^2.1.0"
 thiserror = "1.0.50"
+serde = {version = "1.0.193", features = ["derive"]}
+rmp-serde = "1.1.2"
+
 
 [dev-dependencies]
 env_logger = "0.10.1"

--- a/src/err.rs
+++ b/src/err.rs
@@ -1,7 +1,9 @@
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum ParseError<'a> {
+pub enum ParseError {
     #[error("Invalid Format. Expected [{0}]")]
-    InvalidFormat(&'a str),
+    InvalidFormat(String),
+    #[error("Unknown Section: [{0}]")]
+    UnknownSection(String),
 }

--- a/tests/test_inf.rs
+++ b/tests/test_inf.rs
@@ -77,6 +77,7 @@ mod tests {
 
         let data = include_str!("data/opensslLib.inf").to_string();
         let mut infp = ConfigParser::<Inf>::new();
+
         infp.parse(data).unwrap();
 
         assert!(!infp


### PR DESCRIPTION
Previously, the parser would only lazily parse section entries when entries in that particular section were requested. While this was faster, it is not the experience I want the user to have, as the `parse()` command would succeed, even if there were issues with individual lines in the config file.

This commit updates the parser to parse all sections to ensure they meet the requirements for the given section, but also serializes them to store in an index map as byte arrays. When `get_section_entries` is called, it now deserializes the already-parsed section entries rather than parsing them.